### PR TITLE
Setup @pkgjs/meet for regularly scheduled meetings

### DIFF
--- a/.github/ISSUE_TEMPLATES/meeting.md
+++ b/.github/ISSUE_TEMPLATES/meeting.md
@@ -1,0 +1,42 @@
+## Date/Time
+
+| Timezone | Date/Time |
+|----------|-----------|
+<%= [
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'Europe/London',
+  'Europe/Amsterdam',
+  'Europe/Moscow',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Australia/Sydney'
+].map((zone) => {
+  return `| ${zone} | ${date.setZone(zone).toFormat('EEE dd-MMM-yyyy HH:mm (hh:mm a)')} |`
+}).join('\n') %>
+
+Or in your local time:
+* https://www.timeanddate.com/worldclock/?iso=<%= date.toFormat("yyyy-MM-dd'T'HH:mm:ss") %>
+
+## Agenda
+
+Extracted from **<%= agendaLabel %>** labelled issues and pull requests from **<%= owner %>/<%= repo %>** prior to the meeting.
+
+<%= agendaIssues.map((i) => {
+  return `* ${i.title} [#${i.number}](${i.html_url})`
+}).join('\n') %>
+
+## Invited
+
+@conventional-commits/tsc
+
+## Links
+
+* Minutes:
+
+### Joining the meeting
+
+* link for participants: <TBD>

--- a/.github/workflows/meeting.yml
+++ b/.github/workflows/meeting.yml
@@ -1,0 +1,14 @@
+name: Schedule meetings
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: pkgjs/meet@v0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        schedules: '2020-10-09T17:00:00.0Z/P14D'
+        issueTitle: 'Conventional Commits Steering Meeting <%= date.toFormat("yyyy-MM-dd") %>'
+        agendaLabel: 'tsc-agenda'


### PR DESCRIPTION
This action is developed by the Node.js Package Maintenance Team and used if a few places now.  Thoughts on using it here?

It is setup to create issues for a meeting every 2 weeks starting today (assuming that was the plan).  